### PR TITLE
fix: ensure the filetype is set on lazy load

### DIFF
--- a/lua/mdx/init.lua
+++ b/lua/mdx/init.lua
@@ -6,6 +6,11 @@ function M.setup()
 
     -- Configure treesitter to use the markdown parser for mdx files
     vim.treesitter.language.register("markdown", "mdx")
+
+    -- If the current buffer has the extension mdx, but not the newly create filetype, set it
+    if vim.endswith(vim.api.nvim_buf_get_name(0), ".mdx") and vim.o.filetype ~= "mdx" then
+        vim.o.filetype = "mdx"
+    end
 end
 
 return M


### PR DESCRIPTION
If the plugin is lazy-loaded, creating the new filetype won't be associated to the current buffer automatically.

Fixes #2 