### PR TITLE
readme: Add config function to force treesitter on

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Highlight support for mdx based in [the post] written by [Phelipe Teles].
 
 Note that we don't need to call `config` or define `opts`.
 
+If for some reason treesitter doesn't correctly start for you, try adding this config function.
+
+```lua
+  config = function()
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "mdx",
+      callback = function()
+        vim.treesitter.start()
+      end
+    })
+  end
+```
+
 #### With [vim-plug]
 
 ```vim


### PR DESCRIPTION
For me, for some reason this is the only fix that I found (thanks Claude) which made this whole plugin work. Otherwise treesitter didn't start on mdx files even when I forced it to.

I didn't try this plugin on a clean environment to see if it still happens but I guess it could help somebody down the line.